### PR TITLE
Changes to allow moving reports to clingen

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,3 +5,8 @@ appdata/
 *.tar.gz
 *.zip
 *.tar
+*.xlsx
+*.xls
+*.csv
+*.json
+*.xml

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+old_reports/
+htmlcov/
+appdata/

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,7 @@
 old_reports/
 htmlcov/
 appdata/
+*.log
+*.tar.gz
+*.zip
+*.tar

--- a/.gitignore
+++ b/.gitignore
@@ -92,6 +92,9 @@ data/
 *.xlsx
 *.xls
 
+# Ignore tar.gz
+*.tar.gz
+
 # pyenv
 #   For a library or package, you might want to ignore these files since the code is
 #   intended to run in multiple environments; otherwise, check them in:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM python:3.10-slim-buster
+
+RUN apt-get update && apt-get install -y curl nano rsync
+
+COPY . /app/
+
+RUN pip install -r /app/requirements.txt
+
+WORKDIR /app/

--- a/generate_report_excels.py
+++ b/generate_report_excels.py
@@ -50,6 +50,8 @@ def parse_args():
     parser.add_argument('--created_after', type=str, default=None,
                         help='The date string in the format YYYY-MM-DD\'T\'HH:MM:SS\'Z\''
                         'e.g: 2024-01-01T08:30:00Z to filter reports created after this date. Only allowed in manual mode.')
+    parser.add_argument('--mv-reports', type=bool, default=False,
+                        help='Move reports to the ClinGen folder in the ICI API.')
     args = parser.parse_args()
     # Validate inputs
     if args.created_before == "" or args.created_after == "":
@@ -697,32 +699,30 @@ def json_extract_to_excel(sample_id, case_info,
         write_section(tmb_msi_metric_info_df, "TMB_MSI")
         write_section(case_info_df, "Analyst Information")
 
+def move_reports_to_clingen(destination_dir):
+    """
+    Move reports to the ClinGen folder in the ICI API.
 
-# To deploy, we need to implement the following functions:
-# def move_reports_to_clingen(destination_dir):
-#     """
-#     Move reports to the ClinGen folder in the ICI API.
+    Parameters
+    ----------
+    destination_dir: str
+        The destination directory to move the reports.
 
-#     Parameters
-#     ----------
-#     destination_dir: str
-#         The destination directory to move the reports.
+    Returns
+    -------
+    None
+    """
+    # Move excel files in directory to ClinGen folder
+    destination_dir = "/old_reports"
+    os.makedirs(destination_dir, exist_ok=True)
 
-#     Returns
-#     -------
-#     None
-#     """
-#     # Move excel files in directory to ClinGen folder
-#     destination_dir = "/old_reports"
-#     os.makedirs(destination_dir, exist_ok=True)
-
-#     for f in os.listdir("."):
-#         if f.endswith(".xlsx"):
-#             dest_path = os.path.join(destination_dir, f)
-#             if os.path.exists(dest_path):
-#                 logging.warning(f"File already exists in the new directory: {dest_path}")
-#             else:
-#                 shutil.move(f, dest_path)
+    for f in os.listdir("."):
+        if f.endswith(".xlsx"):
+            dest_path = os.path.join(destination_dir, f)
+            if os.path.exists(dest_path):
+                logging.warning(f"File already exists in the new directory: {dest_path}")
+            else:
+                shutil.move(f, dest_path)
 
 def main():
     """
@@ -775,6 +775,10 @@ def main():
             audit_logs, base_url, headers, report_pattern)
     else:
         logging.warning("No relevant audit logs found.")
+    if args.mv_reports:
+        destination_dir = os.getenv("DESTINATION_DIR")
+        move_reports_to_clingen(destination_dir)
+
     logging.info("Script execution completed.")
 
 

--- a/mv_reports.sh
+++ b/mv_reports.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+SOURCE_DIR="$1"
+DEST_DIR="$2"
+DRY_RUN="$3"
+LOG_FILE="move_log.txt"
+
+if [ "$1" = "-h" ] || [ "$1" = "--help" ]; then
+    echo "Usage: $0 <source_directory> <destination_directory> [--dry-run]"
+    echo "Moves .xlsx files from source to destination. Use --dry-run to log only."
+    exit 0
+fi
+
+if [ -z "$SOURCE_DIR" ] || [ -z "$DEST_DIR" ]; then
+    echo "Usage: $0 <source_directory> <destination_directory> [--dry-run]"
+    exit 1
+fi
+
+for file in "$SOURCE_DIR"/*.xlsx; do
+    if [ -e "$file" ]; then
+        basefile=$(basename "$file")
+        if [ -e "$DEST_DIR/$basefile" ]; then
+            echo "$(date): $basefile already exists in $DEST_DIR. Not moved." >> "$LOG_FILE"
+        else
+            if [ "$DRY_RUN" = "--dry-run" ]; then
+                echo "$(date): Would move $basefile to $DEST_DIR." >> "$LOG_FILE"
+            else
+                mv "$file" "$DEST_DIR"/
+                echo "$(date): Moved $basefile to $DEST_DIR." >> "$LOG_FILE"
+            fi
+        fi
+    fi
+done

--- a/mv_reports.sh
+++ b/mv_reports.sh
@@ -3,7 +3,7 @@
 SOURCE_DIR="$1"
 DEST_DIR="$2"
 DRY_RUN="$3"
-LOG_FILE="move_log.txt"
+LOG_FILE="$4"
 
 if [ "$1" = "-h" ] || [ "$1" = "--help" ]; then
     echo "Usage: $0 <source_directory> <destination_directory> [--dry-run]"
@@ -20,12 +20,20 @@ for file in "$SOURCE_DIR"/*.xlsx; do
     if [ -e "$file" ]; then
         basefile=$(basename "$file")
         if [ -e "$DEST_DIR/$basefile" ]; then
-            echo "$(date): $basefile already exists in $DEST_DIR. Not moved." >> "$LOG_FILE"
+            if [ "$DRY_RUN" = "--dry-run" ]; then
+                echo "$(date): DRYRUN: $basefile already exists in $DEST_DIR. Not moved."
+                echo "$(date): DRYRUN: $basefile already exists in $DEST_DIR. Not moved." >> "$LOG_FILE"
+            else
+                echo "$(date): $basefile already exists in $DEST_DIR. Not moved."
+                echo "$(date): $basefile already exists in $DEST_DIR. Not moved." >> "$LOG_FILE"
+            fi
         else
             if [ "$DRY_RUN" = "--dry-run" ]; then
-                echo "$(date): Would move $basefile to $DEST_DIR." >> "$LOG_FILE"
+                echo "$(date): DRYRUN: Would move $basefile to $DEST_DIR."
+                echo "$(date): DRYRUN: Would move $basefile to $DEST_DIR." >> "$LOG_FILE"
             else
                 mv "$file" "$DEST_DIR"/
+                echo "$(date): Moved $basefile to $DEST_DIR."
                 echo "$(date): Moved $basefile to $DEST_DIR." >> "$LOG_FILE"
             fi
         fi


### PR DESCRIPTION
This pull request makes changes to allow ici_report_export to run on the server, including Dockerization of the project and a new script for moving reports to a specified directory.

### Dockerization and Environment Setup:
* Added a `Dockerfile` to containerize the application, including the installation of required system packages (`curl`, `nano`, `rsync`) and Python dependencies (`requirements.txt`). (`[DockerfileR1-R9](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557R1-R9)`)
* Updated `.dockerignore` to exclude unnecessary files and directories from the Docker build context, such as logs, archives, and temporary files. (`[.dockerignoreR1-R12](diffhunk://#diff-2f754321d62f08ba8392b9b168b83e24ea2852bb5d815d63e767f6c3d23c6ac5R1-R12)`)

### Report Management Enhancements:
* Introduced a new `move_reports_to_clingen` function in `generate_report_excels.py` to move reports to a ClinGen directory, with support for a dry-run mode for testing. (`[generate_report_excels.pyR1159-R1197](diffhunk://#diff-6001a22e0a30672ccaf3e59b73943de792310f53052c1b9ae7a47830bc31b081R1159-R1197)`)
* Added new command-line arguments (`--mv_reports` and `--testing`) to `generate_report_excels.py` for enabling report movement and testing mode. (`[generate_report_excels.pyR195-R202](diffhunk://#diff-6001a22e0a30672ccaf3e59b73943de792310f53052c1b9ae7a47830bc31b081R195-R202)`)
* Integrated the report-moving functionality into the `main()` function, ensuring reports are moved conditionally based on the provided arguments. (`[generate_report_excels.pyR1280-R1292](diffhunk://#diff-6001a22e0a30672ccaf3e59b73943de792310f53052c1b9ae7a47830bc31b081R1280-R1292)`)

### Supporting Scripts:
* Added `mv_reports.sh`, a shell script to handle moving `.xlsx` files from a source to a destination directory, with logging and dry-run capabilities. (`[mv_reports.shR1-R41](diffhunk://#diff-0feaaf6aadef0b175056df0217f9cf6ba9e4a025706aa883a8338a49e82d6035R1-R41)`)