### PR TITLE
Bug Fixes and Improved logging and run option

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -12,3 +12,4 @@ appdata/
 *.csv
 *.json
 *.xml
+output/

--- a/generate_report_excels.py
+++ b/generate_report_excels.py
@@ -1329,15 +1329,14 @@ def main():
 
         if args.mv_reports:
             source_dir = output_directory
-            if not args.single_report:
-                if len(matched_reports) == 0:
-                    logger.info(f"No reports to move to {destination_directory}")
-                else:
-                    move_reports(source_dir, destination_directory, dry_run=args.testing)
+            if len(matched_reports) == 0:
+                logger.info(f"No reports to move to {destination_directory}")
             else:
-                if len(matched_reports) == 0:
-                    logger.info(f"No reports to move to {destination_directory}")
+                if args.single_report:
+                    logger.info(f"Moving single report to {destination_directory}")
+                    move_reports(source_dir, destination_directory, dry_run=args.testing)
                 else:
+                    logger.info(f"Moving reports to {destination_directory}")
                     move_reports(source_dir, destination_directory, dry_run=args.testing)
         else:
             logger.info("--mv_reports not set so not moving reports")

--- a/generate_report_excels.py
+++ b/generate_report_excels.py
@@ -727,7 +727,9 @@ def extract_variant_data(report_json):
 
             # Get consequences from associations
             consequences = select_association_consequences(associations)
-
+            # Get cytoband
+            cytoband = variant.get("cytogeneticBand", "N/A")
+            # Get oncogenicity from associations
             oncogenicity_list = [
                 assoc.get("actionabilityName", "N/A") for assoc in associations
             ]
@@ -737,6 +739,7 @@ def extract_variant_data(report_json):
                 "Gene": gene,
                 "Fold Change": fold_change,
                 "Transcript": transcript,
+                "Cytoband": cytoband,
                 "Oncogenicity": oncogenicity,
                 "Consequences": consequences,
             }
@@ -1084,8 +1087,10 @@ def json_extract_to_excel(sample_id, case_info,
         "Gene",
         "Consequence",
         "Transcript",
+        "Cytoband",
         "Estimated copy number",
         "Tier",
+        "Oncogenicity",
         " ",  # Gap column
         "Fold Change",
     ]
@@ -1348,7 +1353,7 @@ def main():
         raise
 
     finally:
-        send_outcome_notification()
+        send_outcome_notification(args)
 
 
 if __name__ == "__main__":

--- a/generate_report_excels.py
+++ b/generate_report_excels.py
@@ -1085,7 +1085,7 @@ def json_extract_to_excel(sample_id, case_info,
     # Desired columns order for CNVs
     desired_columns = [
         "Gene",
-        "Consequence",
+        "Consequences",
         "Transcript",
         "Cytoband",
         "Estimated copy number",

--- a/utils/notify_slack.py
+++ b/utils/notify_slack.py
@@ -21,8 +21,8 @@ class SlackClient:
                 f"Missing required environment variables: {', '.join(missing_vars)}")
         load_dotenv()  # Load environment variables
         self.webhooks = {
+            "alerts": os.getenv("SLACK_ALERTS_WEBHOOK"),
             "log": os.getenv("SLACK_LOG_WEBHOOK"),
-            "alerts": os.getenv("SLACK_ALERTS_WEBHOOK")
         }
 
     def post_message(self, message, channel) -> None:


### PR DESCRIPTION
This pull request introduces several enhancements and fixes to the `generate_report_excels.py` script, focusing on improved functionality, better error handling, and extra testing.
Key changes include adding support for single-report processing, refining Slack notifications, and updating the testing framework to align with the new features.

### Feature Enhancements:
* Added support for single-report mode with new command-line arguments `--single_report` and `--case_id`. This allows processing a single report while ignoring date arguments. Validation ensures `case_id` is provided when `--single_report` is enabled. 
* Updated the `main()` function to handle single-report processing, including fetching, extracting, and generating reports for a specific case ID.

### Notification Improvements:
* Refactored the `send_outcome_notification()` function to accept command-line arguments (`args`) and added conditional logic for testing mode. Prevents spamming egg-log channel.
* Updated the Slack client initialization in `utils/notify_slack.py` to load webhooks dynamically from environment variables. 

### Additional variant info:
* Added support for extracting and processing the `cytoband` field in variant reports. Updated the JSON-to-Excel export to include these fields in the desired column order.

### Testing:
* Expanded test cases in `tests/test_generate_report_excels.py` to cover the new single-report functionality, argument parsing, and Slack notification logic. Mocked arguments and Slack client interactions to ensure robust test coverage.

### Minor Updates:
* Updated `.dockerignore` to exclude the `output/` directory from Docker builds.